### PR TITLE
[FIX] This fixes #1

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,11 @@
+1.1 (unreleased)
+----------------
+- github #1: support new addons layout on github. The eclipse syntax analyser
+also scan addons directory at root of the cloned directory if exists. BTW,
+code completion is fully functionnal with odoo sources distribution from 
+github
+
+
 1.0 (2014-05-30)
 ----------------
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 def read(*rnames):
     return open(os.path.join(os.path.dirname(__file__), *rnames)).read()
 
-version = '1.0'
+version = '1.1dev'
 
 long_description = (
     read('README.rst')


### PR DESCRIPTION
Support new addons layout on github. If the directory addons exists
at root of the source tree if the cloned odoo repository, it's added
to the collective.recipe.omlette to fix the syntax analyser and
code completion.
